### PR TITLE
Upgrade Hugo to 0.92.0

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,5 +1,5 @@
 options(
-  blogdown.hugo.version = "0.91.2",
+  blogdown.hugo.version = "0.92.0",
   # to automatically serve the site on RStudio startup, set this option to TRUE
   blogdown.serve_site.startup = FALSE,
   # to disable knitting Rmd files on save, set this option to FALSE

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 command = "hugo"
 publish = "www"
 [build.environment]
-HUGO_VERSION = "0.91.2"
+HUGO_VERSION = "0.92.0"
 
 [context]
 [context.branch-deploy]


### PR DESCRIPTION
```
hugo v0.92.0+extended darwin/arm64 BuildDate=unknown
WARN 2022/01/20 21:35:38 .Path when the page is backed by a file is deprecated and will be removed in a future release. We plan to use Path for a canonical source path and you probably want to check the source is a file.
```

Warning from `.Path`used in https://github.com/wowchemy/wowchemy-hugo-themes