### PR TITLE
feat: add bluesky social account

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,6 +43,8 @@ website:
       - text: "{{< iconify fa6-brands:mastodon >}}"
         href: "https://fosstodon.org/@MickaelCanouil"
         rel: me
+      - text: "{{< iconify fa6-brands:bluesky >}}"
+        href: "https://bsky.app/profile/mickael.canouil.fr"
       - text: "{{< iconify fa6-brands:x-twitter >}}"
         href: "https://x.com/MickaelCanouil"
       - text: "{{< iconify fa6-brands:linkedin >}}"

--- a/index.qmd
+++ b/index.qmd
@@ -19,6 +19,9 @@ about:
       href: "https://fosstodon.org/@MickaelCanouil"
       aria-label: "Mastodon logo linking to MickaelCanouil Fosstodon account"
       rel: me
+    - text: "{{< iconify fa6-brands:bluesky >}}"
+      href: "https://bsky.app/profile/mickael.canouil.fr"
+      aria-label: "BlueSky logo linking to mickael.canouil.fr account"
     - text: "{{< iconify fa6-brands:x-twitter >}}"
       href: "https://x.com/MickaelCanouil"
       aria-label: "X (Twitter) logo linking to MickaelCanouil account"


### PR DESCRIPTION
Introduce a link to the Bluesky social account in the website and about sections.