### PR TITLE
fix: Set input placeholder colour to contrast with form background

### DIFF
--- a/assets/stylesheets/coeos.scss
+++ b/assets/stylesheets/coeos.scss
@@ -95,6 +95,8 @@ $input-group-addon-color: $contrast-bg !default;
 $input-group-addon-bg: body-mix(50%) !default;
 $input-group-addon-border-color: transparent !default;
 
+$input-placeholder-color: $body-bg !default;
+
 $form-check-input-bg: $contrast-bg !default;
 $form-check-input-border: none !default;
 


### PR DESCRIPTION
Update the input placeholder colour to contrast with the form background colour for better visibility.