### PR TITLE
fix(posts): use og:title giscus mapping for gribouille post

### DIFF
--- a/_site/blog.html
+++ b/_site/blog.html
@@ -452,7 +452,7 @@ window.Quarto = {
 <div class="quarto-listing quarto-listing-container-custom" id="listing-listing">
 <div class="list blog-list">
 
-  <article class="blog-hero" data-index="0" data-categories="dHlwc3QlMkNxdWFydG8lMkNjb21wdXRhdGlvbiUyQ2dyYW1tYXItb2YtZ3JhcGhpY3M=" data-listing-date-sort="1779235200000" data-listing-file-modified-sort="1779358632434" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="18" data-listing-word-count-sort="3534">
+  <article class="blog-hero" data-index="0" data-categories="dHlwc3QlMkNxdWFydG8lMkNjb21wdXRhdGlvbiUyQ2dyYW1tYXItb2YtZ3JhcGhpY3M=" data-listing-date-sort="1779235200000" data-listing-file-modified-sort="1779359852558" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="18" data-listing-word-count-sort="3534">
     <a class="blog-hero-thumb" href="./posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/featured.png" alt="" loading="lazy"></a>
     <div class="blog-hero-meta">
       <div class="blog-hero-eyebrow">
@@ -473,7 +473,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="1" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDZXh0ZW5zaW9ucyUyQ3ByZXNlbnRhdGlvbnM=" data-listing-date-sort="1776729600000" data-listing-file-modified-sort="1779358632427" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="534">
+  <article class="blog-row blog-row--compact" data-index="1" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDZXh0ZW5zaW9ucyUyQ3ByZXNlbnRhdGlvbnM=" data-listing-date-sort="1776729600000" data-listing-file-modified-sort="1779359852554" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="534">
     <a class="blog-thumb" href="./posts/2026-04-21-quarto-revealjs-extensions/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-04-21-quarto-revealjs-extensions/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Tuesday, the 21st of April, 2026">Tuesday, the 21st of April, 2026</time>
@@ -491,7 +491,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="2" data-categories="cXVhcnRvJTJDYnJhbmQlMkNyJTJDcHl0aG9uJTJDZ2dwbG90MiUyQ3Bsb3RuaW5l" data-listing-date-sort="1776211200000" data-listing-file-modified-sort="1779358632408" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5019">
+  <article class="blog-row blog-row--compact" data-index="2" data-categories="cXVhcnRvJTJDYnJhbmQlMkNyJTJDcHl0aG9uJTJDZ2dwbG90MiUyQ3Bsb3RuaW5l" data-listing-date-sort="1776211200000" data-listing-file-modified-sort="1779359852537" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5019">
     <a class="blog-thumb" href="./posts/2026-04-15-quarto-brand-figures-tables/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-04-15-quarto-brand-figures-tables/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Wednesday, the 15th of April, 2026">Wednesday, the 15th of April, 2026</time>
@@ -509,7 +509,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="3" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772668800000" data-listing-file-modified-sort="1779358632394" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5165">
+  <article class="blog-row blog-row--compact" data-index="3" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772668800000" data-listing-file-modified-sort="1779359852522" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5165">
     <a class="blog-thumb" href="./posts/2026-03-05-typst-template-tutorial-part2/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-03-05-typst-template-tutorial-part2/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 5th of March, 2026">Thursday, the 5th of March, 2026</time>
@@ -527,7 +527,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="4" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772150400000" data-listing-file-modified-sort="1779358632388" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="23" data-listing-word-count-sort="4441">
+  <article class="blog-row blog-row--compact" data-index="4" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772150400000" data-listing-file-modified-sort="1779359852516" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="23" data-listing-word-count-sort="4441">
     <a class="blog-thumb" href="./posts/2026-02-27-typst-template-tutorial-part1/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-02-27-typst-template-tutorial-part1/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Friday, the 27th of February, 2026">Friday, the 27th of February, 2026</time>
@@ -545,7 +545,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="5" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDcGRm" data-listing-date-sort="1768780800000" data-listing-file-modified-sort="1779358632383" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1630">
+  <article class="blog-row blog-row--compact" data-index="5" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDcGRm" data-listing-date-sort="1768780800000" data-listing-file-modified-sort="1779359852511" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1630">
     <a class="blog-thumb" href="./posts/2026-01-19-typst-document-dispatcher/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-01-19-typst-document-dispatcher/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 19th of January, 2026">Monday, the 19th of January, 2026</time>
@@ -563,7 +563,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="6" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1768176000000" data-listing-file-modified-sort="1779358632380" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="633">
+  <article class="blog-row blog-row--compact" data-index="6" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1768176000000" data-listing-file-modified-sort="1779359852508" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="633">
     <a class="blog-thumb" href="./posts/2026-01-12-quarto-wizard-2-0-0/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-01-12-quarto-wizard-2-0-0/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 12th of January, 2026">Monday, the 12th of January, 2026</time>
@@ -581,7 +581,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="7" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwYWN0aW9ucyUyQ2V4dGVuc2lvbnMlMkNhdXRvbWF0aW9uJTJDZGV2b3Bz" data-listing-date-sort="1765497600000" data-listing-file-modified-sort="1779358632375" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="14" data-listing-word-count-sort="2792">
+  <article class="blog-row blog-row--compact" data-index="7" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwYWN0aW9ucyUyQ2V4dGVuc2lvbnMlMkNhdXRvbWF0aW9uJTJDZGV2b3Bz" data-listing-date-sort="1765497600000" data-listing-file-modified-sort="1779359852503" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="14" data-listing-word-count-sort="2792">
     <a class="blog-thumb" href="./posts/2025-12-12-quarto-extensions-updater/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-12-12-quarto-extensions-updater/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Friday, the 12th of December, 2025">Friday, the 12th of December, 2025</time>
@@ -599,7 +599,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="8" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNwcm9kdWN0aXZpdHk=" data-listing-date-sort="1763596800000" data-listing-file-modified-sort="1779358632350" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="7" data-listing-word-count-sort="1235">
+  <article class="blog-row blog-row--compact" data-index="8" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNwcm9kdWN0aXZpdHk=" data-listing-date-sort="1763596800000" data-listing-file-modified-sort="1779359852476" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="7" data-listing-word-count-sort="1235">
     <a class="blog-thumb" href="./posts/2025-11-20-quarto-editor-settings/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-11-20-quarto-editor-settings/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 20th of November, 2025">Thursday, the 20th of November, 2025</time>
@@ -617,7 +617,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="9" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3Byb2R1Y3Rpdml0eSUyQ2Jlc3QlMjBwcmFjdGljZXMlMkNsdWE=" data-listing-date-sort="1762387200000" data-listing-file-modified-sort="1779358632349" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1798">
+  <article class="blog-row blog-row--compact" data-index="9" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3Byb2R1Y3Rpdml0eSUyQ2Jlc3QlMjBwcmFjdGljZXMlMkNsdWE=" data-listing-date-sort="1762387200000" data-listing-file-modified-sort="1779359852476" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1798">
     <a class="blog-thumb" href="./posts/2025-11-06-quarto-extensions-lua/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-11-06-quarto-extensions-lua/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 6th of November, 2025">Thursday, the 6th of November, 2025</time>
@@ -635,7 +635,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="10" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1760918400000" data-listing-file-modified-sort="1779358632348" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="11" data-listing-word-count-sort="2063">
+  <article class="blog-row blog-row--compact" data-index="10" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1760918400000" data-listing-file-modified-sort="1779359852475" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="11" data-listing-word-count-sort="2063">
     <a class="blog-thumb" href="./posts/2025-10-20-quarto-wizard-1-0-0/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-10-20-quarto-wizard-1-0-0/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 20th of October, 2025">Monday, the 20th of October, 2025</time>
@@ -653,7 +653,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="11" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwY29kZXNwYWNlcyUyQ3RlYWNoaW5nJTJDZGV2JTIwY29udGFpbmVy" data-listing-date-sort="1747612800000" data-listing-file-modified-sort="1779358632304" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1904">
+  <article class="blog-row blog-row--compact" data-index="11" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwY29kZXNwYWNlcyUyQ3RlYWNoaW5nJTJDZGV2JTIwY29udGFpbmVy" data-listing-date-sort="1747612800000" data-listing-file-modified-sort="1779359852429" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1904">
     <a class="blog-thumb" href="./posts/2025-05-19-quarto-codespaces/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-05-19-quarto-codespaces/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 19th of May, 2025">Monday, the 19th of May, 2025</time>
@@ -671,7 +671,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="12" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDcGRmJTJDcHJlc2VudGF0aW9ucyUyQ2RlY2t0YXBl" data-listing-date-sort="1745193600000" data-listing-file-modified-sort="1779358632303" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="810">
+  <article class="blog-row blog-row--compact" data-index="12" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDcGRmJTJDcHJlc2VudGF0aW9ucyUyQ2RlY2t0YXBl" data-listing-date-sort="1745193600000" data-listing-file-modified-sort="1779359852428" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="810">
     <a class="blog-thumb" href="./posts/2025-04-21-quarto-revealjs-tabset-pdf/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-04-21-quarto-revealjs-tabset-pdf/featured.gif" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 21st of April, 2025">Monday, the 21st of April, 2025</time>
@@ -689,7 +689,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="13" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwcGFnZXMlMkNwdWJsaXNoaW5nJTJDZGVwbG95bWVudCUyQ2dpdGh1YiUyMGFjdGlvbnM=" data-listing-date-sort="1735516800000" data-listing-file-modified-sort="1779358632296" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="13" data-listing-word-count-sort="2516">
+  <article class="blog-row blog-row--compact" data-index="13" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwcGFnZXMlMkNwdWJsaXNoaW5nJTJDZGVwbG95bWVudCUyQ2dpdGh1YiUyMGFjdGlvbnM=" data-listing-date-sort="1735516800000" data-listing-file-modified-sort="1779359852422" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="13" data-listing-word-count-sort="2516">
     <a class="blog-thumb" href="./posts/2024-12-30-quarto-github-pages/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2024-12-30-quarto-github-pages/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 30th of December, 2024">Monday, the 30th of December, 2024</time>
@@ -707,7 +707,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="14" data-categories="cXVhcnRvJTJDcSUyNmElMkNqYXZhc2NyaXB0JTJDdGhlbWUlMkNkYXJrJTIwbW9kZSUyQ2xpZ2h0JTIwbW9kZQ==" data-listing-date-sort="1685404800000" data-listing-file-modified-sort="1779358632295" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="414">
+  <article class="blog-row blog-row--compact" data-index="14" data-categories="cXVhcnRvJTJDcSUyNmElMkNqYXZhc2NyaXB0JTJDdGhlbWUlMkNkYXJrJTIwbW9kZSUyQ2xpZ2h0JTIwbW9kZQ==" data-listing-date-sort="1685404800000" data-listing-file-modified-sort="1779359852421" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="414">
     <a class="blog-thumb" href="./posts/2023-05-30-quarto-light-dark/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-05-30-quarto-light-dark/featured.gif" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Tuesday, the 30th of May, 2023">Tuesday, the 30th of May, 2023</time>
@@ -725,7 +725,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="15" data-categories="cXVhcnRvJTJDcSUyNmElMkNkb2NrZXI=" data-listing-date-sort="1683417600000" data-listing-file-modified-sort="1779358632287" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1867">
+  <article class="blog-row blog-row--compact" data-index="15" data-categories="cXVhcnRvJTJDcSUyNmElMkNkb2NrZXI=" data-listing-date-sort="1683417600000" data-listing-file-modified-sort="1779359852413" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1867">
     <a class="blog-thumb" href="./posts/2023-05-07-quarto-docker/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-05-07-quarto-docker/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Sunday, the 7th of May, 2023">Sunday, the 7th of May, 2023</time>
@@ -743,7 +743,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="16" data-categories="cXVhcnRvJTJDcSUyNmElMkNtYXRoamF4JTJDbGF0ZXg=" data-listing-date-sort="1678579200000" data-listing-file-modified-sort="1779358632286" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="212">
+  <article class="blog-row blog-row--compact" data-index="16" data-categories="cXVhcnRvJTJDcSUyNmElMkNtYXRoamF4JTJDbGF0ZXg=" data-listing-date-sort="1678579200000" data-listing-file-modified-sort="1779359852412" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="212">
     <a class="blog-thumb" href="./posts/2023-03-12-quarto-mathjax-packages/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-03-12-quarto-mathjax-packages/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Sunday, the 12th of March, 2023">Sunday, the 12th of March, 2023</time>
@@ -761,7 +761,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="17" data-categories="cXVhcnRvJTJDcSUyNmElMkNyJTJDa25pdHI=" data-listing-date-sort="1677974400000" data-listing-file-modified-sort="1779358632286" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="310">
+  <article class="blog-row blog-row--compact" data-index="17" data-categories="cXVhcnRvJTJDcSUyNmElMkNyJTJDa25pdHI=" data-listing-date-sort="1677974400000" data-listing-file-modified-sort="1779359852411" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="310">
     <a class="blog-thumb" href="./posts/2023-03-05-quarto-auto-table-crossref/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-03-05-quarto-auto-table-crossref/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Sunday, the 5th of March, 2023">Sunday, the 5th of March, 2023</time>
@@ -779,7 +779,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="18" data-categories="ciUyQ2Jsb2dkb3duJTJDcm1hcmtkb3duJTJDaHVnbyUyQ3dlYnNpdGU=" data-listing-date-sort="1620259200000" data-listing-file-modified-sort="1779358632285" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="16" data-listing-word-count-sort="3098">
+  <article class="blog-row blog-row--compact" data-index="18" data-categories="ciUyQ2Jsb2dkb3duJTJDcm1hcmtkb3duJTJDaHVnbyUyQ3dlYnNpdGU=" data-listing-date-sort="1620259200000" data-listing-file-modified-sort="1779359852410" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="16" data-listing-word-count-sort="3098">
     <a class="blog-thumb" href="./posts/2021-05-06-floating-toc-in-blogdown/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2021-05-06-floating-toc-in-blogdown/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 6th of May, 2021">Thursday, the 6th of May, 2021</time>
@@ -797,7 +797,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="19" data-categories="ciUyQ3Zpc3VhbGlzYXRpb24lMkNnZ3Bsb3QyJTJDZ2dhbmltYXRlJTJDZnVu" data-listing-date-sort="1588723200000" data-listing-file-modified-sort="1779358632269" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="29" data-listing-word-count-sort="5615">
+  <article class="blog-row blog-row--compact" data-index="19" data-categories="ciUyQ3Zpc3VhbGlzYXRpb24lMkNnZ3Bsb3QyJTJDZ2dhbmltYXRlJTJDZnVu" data-listing-date-sort="1588723200000" data-listing-file-modified-sort="1779359852394" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="29" data-listing-word-count-sort="5615">
     <a class="blog-thumb" href="./posts/2020-05-06-ggpacman/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2020-05-06-ggpacman/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Wednesday, the 6th of May, 2020">Wednesday, the 6th of May, 2020</time>

--- a/_site/blog.xml
+++ b/_site/blog.xml
@@ -2117,7 +2117,7 @@ font-style: inherit;">- </span>[]{.fragment .grow fragment-index="3"} Step three
 <section id="live-demo" class="level3" data-number="2.4">
 <h3 data-number="2.4" class="anchored" data-anchor-id="live-demo"><span class="header-section-number">2.4</span> Live demo</h3>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-fragmention.html" class="lightbox" data-gallery="quarto-lightbox-gallery-2" title=""><embed src="assets/slides/demo-fragmention.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-fragmention.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-2"><embed src="assets/slides/demo-fragmention.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 </section>
@@ -2220,7 +2220,7 @@ font-style: inherit;">4. </span>Sort the resulting table.</span></code></pre></d
 <section id="live-demo-1" class="level3" data-number="3.4">
 <h3 data-number="3.4" class="anchored" data-anchor-id="live-demo-1"><span class="header-section-number">3.4</span> Live demo</h3>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-codefrag.html" class="lightbox" data-gallery="quarto-lightbox-gallery-3" title=""><embed src="assets/slides/demo-codefrag.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-codefrag.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-3"><embed src="assets/slides/demo-codefrag.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 </section>
@@ -2305,7 +2305,7 @@ font-style: inherit;">- </span>No regression on the held-out split.</span></code
 <section id="live-demo-2" class="level3" data-number="4.4">
 <h3 data-number="4.4" class="anchored" data-anchor-id="live-demo-2"><span class="header-section-number">4.4</span> Live demo</h3>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-cascade.html" class="lightbox" data-gallery="quarto-lightbox-gallery-4" title=""><embed src="assets/slides/demo-cascade.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-cascade.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-4"><embed src="assets/slides/demo-cascade.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 </section>
@@ -2411,7 +2411,7 @@ font-style: inherit;">- </span>Duplicates removed before splitting.</span>
 <section id="live-demo-3" class="level3" data-number="5.4">
 <h3 data-number="5.4" class="anchored" data-anchor-id="live-demo-3"><span class="header-section-number">5.4</span> Live demo</h3>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-tabset.html" class="lightbox" data-gallery="quarto-lightbox-gallery-5" title=""><embed src="assets/slides/demo-tabset.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-tabset.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-5"><embed src="assets/slides/demo-tabset.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 </section>
@@ -2463,7 +2463,7 @@ font-style: inherit;">-</span><span class="at" style="color: #657422;
 background-color: null;
 font-style: inherit;"> tabset</span></span></code></pre></div></div>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-combined.html" class="lightbox" data-gallery="quarto-lightbox-gallery-6" title=""><embed src="assets/slides/demo-combined.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-combined.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-6"><embed src="assets/slides/demo-combined.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 <section id="wrap-up" class="level2" data-number="7">

--- a/_site/posts/2026-04-21-quarto-revealjs-extensions/index.html
+++ b/_site/posts/2026-04-21-quarto-revealjs-extensions/index.html
@@ -547,7 +547,7 @@ and tabset in rose, each with a numbered badge and a short description.
 <section id="live-demo" class="level3" data-number="2.4">
 <h3 data-number="2.4" class="anchored" data-anchor-id="live-demo"><span class="header-section-number">2.4</span> Live demo</h3>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-fragmention.html" class="lightbox" data-gallery="quarto-lightbox-gallery-2" title=""><embed src="assets/slides/demo-fragmention.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-fragmention.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-2"><embed src="assets/slides/demo-fragmention.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 </section>
@@ -584,7 +584,7 @@ and tabset in rose, each with a numbered badge and a short description.
 <section id="live-demo-1" class="level3" data-number="3.4">
 <h3 data-number="3.4" class="anchored" data-anchor-id="live-demo-1"><span class="header-section-number">3.4</span> Live demo</h3>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-codefrag.html" class="lightbox" data-gallery="quarto-lightbox-gallery-3" title=""><embed src="assets/slides/demo-codefrag.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-codefrag.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-3"><embed src="assets/slides/demo-codefrag.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 </section>
@@ -631,7 +631,7 @@ and tabset in rose, each with a numbered badge and a short description.
 <section id="live-demo-2" class="level3" data-number="4.4">
 <h3 data-number="4.4" class="anchored" data-anchor-id="live-demo-2"><span class="header-section-number">4.4</span> Live demo</h3>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-cascade.html" class="lightbox" data-gallery="quarto-lightbox-gallery-4" title=""><embed src="assets/slides/demo-cascade.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-cascade.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-4"><embed src="assets/slides/demo-cascade.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 </section>
@@ -675,7 +675,7 @@ and tabset in rose, each with a numbered badge and a short description.
 <section id="live-demo-3" class="level3" data-number="5.4">
 <h3 data-number="5.4" class="anchored" data-anchor-id="live-demo-3"><span class="header-section-number">5.4</span> Live demo</h3>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-tabset.html" class="lightbox" data-gallery="quarto-lightbox-gallery-5" title=""><embed src="assets/slides/demo-tabset.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-tabset.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-5"><embed src="assets/slides/demo-tabset.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 </section>
@@ -689,7 +689,7 @@ and tabset in rose, each with a numbered badge and a short description.
 <span id="cb13-9"><a href="#cb13-9" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="kw">-</span><span class="at"> codefrag</span></span>
 <span id="cb13-10"><a href="#cb13-10" aria-hidden="true" tabindex="-1"></a><span class="at">  </span><span class="kw">-</span><span class="at"> tabset</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div style="text-align: center;">
-<p><a href="assets/slides/demo-combined.html" class="lightbox" data-gallery="quarto-lightbox-gallery-6" title=""><embed src="assets/slides/demo-combined.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/slides/demo-combined.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-6"><embed src="assets/slides/demo-combined.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 <section id="wrap-up" class="level2" data-number="7">

--- a/_site/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html
+++ b/_site/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html
@@ -2034,7 +2034,7 @@ CANOUIL, M. (2026-05-20). Gribouille: a Grammar of Graphics for Typst.
     script.dataset.repoId = "R_kgDOSGUuww";
     script.dataset.category = "Announcements";
     script.dataset.categoryId = "DIC_kwDOSGUuw84C7KIV";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/sitemap.xml
+++ b/_site/sitemap.xml
@@ -2,102 +2,102 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mickael.canouil.fr/talks/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.499Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.624Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/projects/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.492Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.618Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/blog.html</loc>
-    <lastmod>2026-05-21T10:17:12.269Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.394Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-05-30-quarto-light-dark/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.295Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.421Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-01-12-quarto-wizard-2-0-0/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.380Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.508Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-11-20-quarto-editor-settings/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.350Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.476Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-04-15-quarto-brand-figures-tables/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.408Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.537Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2021-05-06-floating-toc-in-blogdown/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.285Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.410Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.434Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.558Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-04-21-quarto-revealjs-extensions/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.427Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.554Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-12-12-quarto-extensions-updater/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.375Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.503Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-01-19-typst-document-dispatcher/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.383Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.511Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-03-05-quarto-auto-table-crossref/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.286Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.411Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-05-19-quarto-codespaces/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.304Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.429Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-03-12-quarto-mathjax-packages/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.286Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.412Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-04-21-quarto-revealjs-tabset-pdf/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.303Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.428Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-02-27-typst-template-tutorial-part1/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.388Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.516Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-03-05-typst-template-tutorial-part2/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.394Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.522Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-10-20-quarto-wizard-1-0-0/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.348Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.475Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-05-07-quarto-docker/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.287Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.413Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-11-06-quarto-extensions-lua/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.349Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.476Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2020-05-06-ggpacman/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.269Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.394Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2024-12-30-quarto-github-pages/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.296Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.422Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/publications/index.html</loc>
-    <lastmod>2026-05-21T10:18:25.117Z</lastmod>
+    <lastmod>2026-05-21T10:38:30.958Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/index.html</loc>
-    <lastmod>2026-05-21T10:17:12.269Z</lastmod>
+    <lastmod>2026-05-21T10:37:32.394Z</lastmod>
   </url>
 </urlset>

--- a/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.qmd
+++ b/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.qmd
@@ -38,7 +38,7 @@ extensions:
       dark: "#f5f5f4"
 comments:
   giscus:
-    mapping: title
+    mapping: "og:title"
     theme:
       dark: dark_dimmed
       light: light


### PR DESCRIPTION
## Problem

The Gribouille post used `mapping: title` for giscus. giscus took the full HTML page title (`Gribouille: a Grammar of Graphics for Typst – Mickaël CANOUIL`, including the site suffix) as its term and round-tripped it through its iframe URL query, so non-ASCII characters became percent-encoded:

- en-dash `–` (U+2013) → `%E2%80%93`
- `ë` (U+00EB) → `%C3%AB`

The auto-created GitHub Discussion stored that encoded term as its title.

## Change

Switch the post's giscus `mapping` to `og:title`. Scope is this post only; `posts/_metadata.yml` is unchanged.

## Note

og:title still carries the `–`/`ë` from the site suffix, so the encoding may recur. If so, follow-up: strip the site suffix from og:title or move to `pathname`/`specific` mapping.

The previously created malformed discussion in `mcanouil/gribouille` stays orphaned and should be deleted on GitHub.