### PR TITLE
fix(posts): use title giscus mapping for gribouille post

### DIFF
--- a/_site/blog.html
+++ b/_site/blog.html
@@ -452,7 +452,7 @@ window.Quarto = {
 <div class="quarto-listing quarto-listing-container-custom" id="listing-listing">
 <div class="list blog-list">
 
-  <article class="blog-hero" data-index="0" data-categories="dHlwc3QlMkNxdWFydG8lMkNjb21wdXRhdGlvbiUyQ2dyYW1tYXItb2YtZ3JhcGhpY3M=" data-listing-date-sort="1779235200000" data-listing-file-modified-sort="1779362214504" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="18" data-listing-word-count-sort="3534">
+  <article class="blog-hero" data-index="0" data-categories="dHlwc3QlMkNxdWFydG8lMkNjb21wdXRhdGlvbiUyQ2dyYW1tYXItb2YtZ3JhcGhpY3M=" data-listing-date-sort="1779235200000" data-listing-file-modified-sort="1779362637772" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="18" data-listing-word-count-sort="3534">
     <a class="blog-hero-thumb" href="./posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/featured.png" alt="" loading="lazy"></a>
     <div class="blog-hero-meta">
       <div class="blog-hero-eyebrow">
@@ -473,7 +473,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="1" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDZXh0ZW5zaW9ucyUyQ3ByZXNlbnRhdGlvbnM=" data-listing-date-sort="1776729600000" data-listing-file-modified-sort="1779362214500" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="534">
+  <article class="blog-row blog-row--compact" data-index="1" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDZXh0ZW5zaW9ucyUyQ3ByZXNlbnRhdGlvbnM=" data-listing-date-sort="1776729600000" data-listing-file-modified-sort="1779362637767" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="534">
     <a class="blog-thumb" href="./posts/2026-04-21-quarto-revealjs-extensions/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-04-21-quarto-revealjs-extensions/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Tuesday, the 21st of April, 2026">Tuesday, the 21st of April, 2026</time>
@@ -491,7 +491,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="2" data-categories="cXVhcnRvJTJDYnJhbmQlMkNyJTJDcHl0aG9uJTJDZ2dwbG90MiUyQ3Bsb3RuaW5l" data-listing-date-sort="1776211200000" data-listing-file-modified-sort="1779362214479" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5019">
+  <article class="blog-row blog-row--compact" data-index="2" data-categories="cXVhcnRvJTJDYnJhbmQlMkNyJTJDcHl0aG9uJTJDZ2dwbG90MiUyQ3Bsb3RuaW5l" data-listing-date-sort="1776211200000" data-listing-file-modified-sort="1779362637746" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5019">
     <a class="blog-thumb" href="./posts/2026-04-15-quarto-brand-figures-tables/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-04-15-quarto-brand-figures-tables/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Wednesday, the 15th of April, 2026">Wednesday, the 15th of April, 2026</time>
@@ -509,7 +509,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="3" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772668800000" data-listing-file-modified-sort="1779362214463" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5165">
+  <article class="blog-row blog-row--compact" data-index="3" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772668800000" data-listing-file-modified-sort="1779362637730" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5165">
     <a class="blog-thumb" href="./posts/2026-03-05-typst-template-tutorial-part2/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-03-05-typst-template-tutorial-part2/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 5th of March, 2026">Thursday, the 5th of March, 2026</time>
@@ -527,7 +527,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="4" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772150400000" data-listing-file-modified-sort="1779362214457" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="23" data-listing-word-count-sort="4441">
+  <article class="blog-row blog-row--compact" data-index="4" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772150400000" data-listing-file-modified-sort="1779362637724" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="23" data-listing-word-count-sort="4441">
     <a class="blog-thumb" href="./posts/2026-02-27-typst-template-tutorial-part1/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-02-27-typst-template-tutorial-part1/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Friday, the 27th of February, 2026">Friday, the 27th of February, 2026</time>
@@ -545,7 +545,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="5" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDcGRm" data-listing-date-sort="1768780800000" data-listing-file-modified-sort="1779362214452" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1630">
+  <article class="blog-row blog-row--compact" data-index="5" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDcGRm" data-listing-date-sort="1768780800000" data-listing-file-modified-sort="1779362637719" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1630">
     <a class="blog-thumb" href="./posts/2026-01-19-typst-document-dispatcher/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-01-19-typst-document-dispatcher/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 19th of January, 2026">Monday, the 19th of January, 2026</time>
@@ -563,7 +563,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="6" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1768176000000" data-listing-file-modified-sort="1779362214448" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="633">
+  <article class="blog-row blog-row--compact" data-index="6" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1768176000000" data-listing-file-modified-sort="1779362637715" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="633">
     <a class="blog-thumb" href="./posts/2026-01-12-quarto-wizard-2-0-0/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-01-12-quarto-wizard-2-0-0/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 12th of January, 2026">Monday, the 12th of January, 2026</time>
@@ -581,7 +581,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="7" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwYWN0aW9ucyUyQ2V4dGVuc2lvbnMlMkNhdXRvbWF0aW9uJTJDZGV2b3Bz" data-listing-date-sort="1765497600000" data-listing-file-modified-sort="1779362214443" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="14" data-listing-word-count-sort="2792">
+  <article class="blog-row blog-row--compact" data-index="7" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwYWN0aW9ucyUyQ2V4dGVuc2lvbnMlMkNhdXRvbWF0aW9uJTJDZGV2b3Bz" data-listing-date-sort="1765497600000" data-listing-file-modified-sort="1779362637710" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="14" data-listing-word-count-sort="2792">
     <a class="blog-thumb" href="./posts/2025-12-12-quarto-extensions-updater/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-12-12-quarto-extensions-updater/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Friday, the 12th of December, 2025">Friday, the 12th of December, 2025</time>
@@ -599,7 +599,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="8" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNwcm9kdWN0aXZpdHk=" data-listing-date-sort="1763596800000" data-listing-file-modified-sort="1779362214416" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="7" data-listing-word-count-sort="1235">
+  <article class="blog-row blog-row--compact" data-index="8" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNwcm9kdWN0aXZpdHk=" data-listing-date-sort="1763596800000" data-listing-file-modified-sort="1779362637683" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="7" data-listing-word-count-sort="1235">
     <a class="blog-thumb" href="./posts/2025-11-20-quarto-editor-settings/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-11-20-quarto-editor-settings/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 20th of November, 2025">Thursday, the 20th of November, 2025</time>
@@ -617,7 +617,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="9" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3Byb2R1Y3Rpdml0eSUyQ2Jlc3QlMjBwcmFjdGljZXMlMkNsdWE=" data-listing-date-sort="1762387200000" data-listing-file-modified-sort="1779362214415" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1798">
+  <article class="blog-row blog-row--compact" data-index="9" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3Byb2R1Y3Rpdml0eSUyQ2Jlc3QlMjBwcmFjdGljZXMlMkNsdWE=" data-listing-date-sort="1762387200000" data-listing-file-modified-sort="1779362637682" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1798">
     <a class="blog-thumb" href="./posts/2025-11-06-quarto-extensions-lua/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-11-06-quarto-extensions-lua/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 6th of November, 2025">Thursday, the 6th of November, 2025</time>
@@ -635,7 +635,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="10" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1760918400000" data-listing-file-modified-sort="1779362214413" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="11" data-listing-word-count-sort="2063">
+  <article class="blog-row blog-row--compact" data-index="10" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1760918400000" data-listing-file-modified-sort="1779362637680" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="11" data-listing-word-count-sort="2063">
     <a class="blog-thumb" href="./posts/2025-10-20-quarto-wizard-1-0-0/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-10-20-quarto-wizard-1-0-0/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 20th of October, 2025">Monday, the 20th of October, 2025</time>
@@ -653,7 +653,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="11" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwY29kZXNwYWNlcyUyQ3RlYWNoaW5nJTJDZGV2JTIwY29udGFpbmVy" data-listing-date-sort="1747612800000" data-listing-file-modified-sort="1779362214365" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1904">
+  <article class="blog-row blog-row--compact" data-index="11" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwY29kZXNwYWNlcyUyQ3RlYWNoaW5nJTJDZGV2JTIwY29udGFpbmVy" data-listing-date-sort="1747612800000" data-listing-file-modified-sort="1779362637632" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1904">
     <a class="blog-thumb" href="./posts/2025-05-19-quarto-codespaces/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-05-19-quarto-codespaces/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 19th of May, 2025">Monday, the 19th of May, 2025</time>
@@ -671,7 +671,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="12" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDcGRmJTJDcHJlc2VudGF0aW9ucyUyQ2RlY2t0YXBl" data-listing-date-sort="1745193600000" data-listing-file-modified-sort="1779362214363" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="810">
+  <article class="blog-row blog-row--compact" data-index="12" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDcGRmJTJDcHJlc2VudGF0aW9ucyUyQ2RlY2t0YXBl" data-listing-date-sort="1745193600000" data-listing-file-modified-sort="1779362637630" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="810">
     <a class="blog-thumb" href="./posts/2025-04-21-quarto-revealjs-tabset-pdf/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-04-21-quarto-revealjs-tabset-pdf/featured.gif" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 21st of April, 2025">Monday, the 21st of April, 2025</time>
@@ -689,7 +689,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="13" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwcGFnZXMlMkNwdWJsaXNoaW5nJTJDZGVwbG95bWVudCUyQ2dpdGh1YiUyMGFjdGlvbnM=" data-listing-date-sort="1735516800000" data-listing-file-modified-sort="1779362214357" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="13" data-listing-word-count-sort="2516">
+  <article class="blog-row blog-row--compact" data-index="13" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwcGFnZXMlMkNwdWJsaXNoaW5nJTJDZGVwbG95bWVudCUyQ2dpdGh1YiUyMGFjdGlvbnM=" data-listing-date-sort="1735516800000" data-listing-file-modified-sort="1779362637624" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="13" data-listing-word-count-sort="2516">
     <a class="blog-thumb" href="./posts/2024-12-30-quarto-github-pages/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2024-12-30-quarto-github-pages/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 30th of December, 2024">Monday, the 30th of December, 2024</time>
@@ -707,7 +707,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="14" data-categories="cXVhcnRvJTJDcSUyNmElMkNqYXZhc2NyaXB0JTJDdGhlbWUlMkNkYXJrJTIwbW9kZSUyQ2xpZ2h0JTIwbW9kZQ==" data-listing-date-sort="1685404800000" data-listing-file-modified-sort="1779362214355" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="414">
+  <article class="blog-row blog-row--compact" data-index="14" data-categories="cXVhcnRvJTJDcSUyNmElMkNqYXZhc2NyaXB0JTJDdGhlbWUlMkNkYXJrJTIwbW9kZSUyQ2xpZ2h0JTIwbW9kZQ==" data-listing-date-sort="1685404800000" data-listing-file-modified-sort="1779362637622" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="414">
     <a class="blog-thumb" href="./posts/2023-05-30-quarto-light-dark/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-05-30-quarto-light-dark/featured.gif" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Tuesday, the 30th of May, 2023">Tuesday, the 30th of May, 2023</time>
@@ -725,7 +725,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="15" data-categories="cXVhcnRvJTJDcSUyNmElMkNkb2NrZXI=" data-listing-date-sort="1683417600000" data-listing-file-modified-sort="1779362214347" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1867">
+  <article class="blog-row blog-row--compact" data-index="15" data-categories="cXVhcnRvJTJDcSUyNmElMkNkb2NrZXI=" data-listing-date-sort="1683417600000" data-listing-file-modified-sort="1779362637614" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1867">
     <a class="blog-thumb" href="./posts/2023-05-07-quarto-docker/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-05-07-quarto-docker/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Sunday, the 7th of May, 2023">Sunday, the 7th of May, 2023</time>
@@ -743,7 +743,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="16" data-categories="cXVhcnRvJTJDcSUyNmElMkNtYXRoamF4JTJDbGF0ZXg=" data-listing-date-sort="1678579200000" data-listing-file-modified-sort="1779362214346" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="212">
+  <article class="blog-row blog-row--compact" data-index="16" data-categories="cXVhcnRvJTJDcSUyNmElMkNtYXRoamF4JTJDbGF0ZXg=" data-listing-date-sort="1678579200000" data-listing-file-modified-sort="1779362637613" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="212">
     <a class="blog-thumb" href="./posts/2023-03-12-quarto-mathjax-packages/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-03-12-quarto-mathjax-packages/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Sunday, the 12th of March, 2023">Sunday, the 12th of March, 2023</time>
@@ -761,7 +761,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="17" data-categories="cXVhcnRvJTJDcSUyNmElMkNyJTJDa25pdHI=" data-listing-date-sort="1677974400000" data-listing-file-modified-sort="1779362214345" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="310">
+  <article class="blog-row blog-row--compact" data-index="17" data-categories="cXVhcnRvJTJDcSUyNmElMkNyJTJDa25pdHI=" data-listing-date-sort="1677974400000" data-listing-file-modified-sort="1779362637612" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="310">
     <a class="blog-thumb" href="./posts/2023-03-05-quarto-auto-table-crossref/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-03-05-quarto-auto-table-crossref/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Sunday, the 5th of March, 2023">Sunday, the 5th of March, 2023</time>
@@ -779,7 +779,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="18" data-categories="ciUyQ2Jsb2dkb3duJTJDcm1hcmtkb3duJTJDaHVnbyUyQ3dlYnNpdGU=" data-listing-date-sort="1620259200000" data-listing-file-modified-sort="1779362214343" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="16" data-listing-word-count-sort="3098">
+  <article class="blog-row blog-row--compact" data-index="18" data-categories="ciUyQ2Jsb2dkb3duJTJDcm1hcmtkb3duJTJDaHVnbyUyQ3dlYnNpdGU=" data-listing-date-sort="1620259200000" data-listing-file-modified-sort="1779362637610" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="16" data-listing-word-count-sort="3098">
     <a class="blog-thumb" href="./posts/2021-05-06-floating-toc-in-blogdown/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2021-05-06-floating-toc-in-blogdown/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 6th of May, 2021">Thursday, the 6th of May, 2021</time>
@@ -797,7 +797,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="19" data-categories="ciUyQ3Zpc3VhbGlzYXRpb24lMkNnZ3Bsb3QyJTJDZ2dhbmltYXRlJTJDZnVu" data-listing-date-sort="1588723200000" data-listing-file-modified-sort="1779362214327" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="29" data-listing-word-count-sort="5615">
+  <article class="blog-row blog-row--compact" data-index="19" data-categories="ciUyQ3Zpc3VhbGlzYXRpb24lMkNnZ3Bsb3QyJTJDZ2dhbmltYXRlJTJDZnVu" data-listing-date-sort="1588723200000" data-listing-file-modified-sort="1779362637595" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="29" data-listing-word-count-sort="5615">
     <a class="blog-thumb" href="./posts/2020-05-06-ggpacman/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2020-05-06-ggpacman/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Wednesday, the 6th of May, 2020">Wednesday, the 6th of May, 2020</time>

--- a/_site/blog.xml
+++ b/_site/blog.xml
@@ -22272,7 +22272,7 @@ font-style: inherit;">"Penguin Species"</span></span>
 background-color: null;
 font-style: inherit;">```</span></span></code></pre></div></div>
 </details>
-<div class="quarto-layout-panel" style="text-align:center;" data-layout-ncol="2">
+<div class="quarto-layout-panel" data-layout-ncol="2" style="text-align:center;">
 <div class="quarto-layout-row">
 <div class="quarto-layout-cell" style="flex-basis: 50.0%;justify-content: flex-start;">
 <div class="quarto-figure quarto-figure-center">

--- a/_site/posts/2023-05-30-quarto-light-dark/index.html
+++ b/_site/posts/2023-05-30-quarto-light-dark/index.html
@@ -705,7 +705,7 @@ This time, I will show how to have images both for light and dark theme, when sw
 <span id="cb8-92"><a href="#cb8-92" aria-hidden="true" tabindex="-1"></a>  )</span>
 <span id="cb8-93"><a href="#cb8-93" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </details>
-<div class="quarto-layout-panel" style="text-align:center;" data-layout-ncol="2">
+<div class="quarto-layout-panel" data-layout-ncol="2" style="text-align:center;">
 <div class="quarto-layout-row">
 <div class="quarto-layout-cell" style="flex-basis: 50.0%;justify-content: flex-start;">
 <div class="quarto-figure quarto-figure-center">

--- a/_site/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html
+++ b/_site/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html
@@ -2034,7 +2034,7 @@ CANOUIL, M. (2026-05-20). Gribouille: a Grammar of Graphics for Typst.
     script.dataset.repoId = "R_kgDOSGUuww";
     script.dataset.category = "Announcements";
     script.dataset.categoryId = "DIC_kwDOSGUuw84C7KIV";
-    script.dataset.mapping = "Gribouille: a Grammar of Graphics for Typst";
+    script.dataset.mapping = "title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/sitemap.xml
+++ b/_site/sitemap.xml
@@ -2,102 +2,102 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mickael.canouil.fr/talks/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.576Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.843Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/projects/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.567Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.834Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/blog.html</loc>
-    <lastmod>2026-05-21T11:16:54.326Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.594Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-05-30-quarto-light-dark/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.355Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.622Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-01-12-quarto-wizard-2-0-0/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.448Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.715Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-11-20-quarto-editor-settings/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.416Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.683Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-04-15-quarto-brand-figures-tables/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.479Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.746Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2021-05-06-floating-toc-in-blogdown/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.343Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.610Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.504Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.772Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-04-21-quarto-revealjs-extensions/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.500Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.767Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-12-12-quarto-extensions-updater/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.443Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.710Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-01-19-typst-document-dispatcher/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.452Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.719Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-03-05-quarto-auto-table-crossref/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.345Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.612Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-05-19-quarto-codespaces/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.365Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.632Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-03-12-quarto-mathjax-packages/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.346Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.613Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-04-21-quarto-revealjs-tabset-pdf/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.363Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.630Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-02-27-typst-template-tutorial-part1/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.457Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.724Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-03-05-typst-template-tutorial-part2/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.463Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.730Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-10-20-quarto-wizard-1-0-0/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.413Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.680Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-05-07-quarto-docker/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.347Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.614Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-11-06-quarto-extensions-lua/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.415Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.682Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2020-05-06-ggpacman/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.327Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.595Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2024-12-30-quarto-github-pages/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.357Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.624Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/publications/index.html</loc>
-    <lastmod>2026-05-21T11:17:49.230Z</lastmod>
+    <lastmod>2026-05-21T11:24:57.161Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/index.html</loc>
-    <lastmod>2026-05-21T11:16:54.326Z</lastmod>
+    <lastmod>2026-05-21T11:23:57.594Z</lastmod>
   </url>
 </urlset>

--- a/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.qmd
+++ b/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.qmd
@@ -38,7 +38,7 @@ extensions:
       dark: "#f5f5f4"
 comments:
   giscus:
-    mapping: "Gribouille: a Grammar of Graphics for Typst"
+    mapping: "title"
     theme:
       dark: dark_dimmed
       light: light


### PR DESCRIPTION
Switch the giscus discussion mapping for the Gribouille post to the title strategy so the thread tracks the page title automatically.