### PR TITLE
fix(posts): set giscus og:title mapping site-wide

### DIFF
--- a/_site/blog.html
+++ b/_site/blog.html
@@ -116,10 +116,10 @@ ul.task-list li input[type="checkbox"] {
     }
 
     const options = {
-      valueNames: ['listing-project','listing-website','listing-format','listing-lightbox','listing-execute','listing-filters','listing-extensions','listing-engines','listing-language','listing-freeze','listing-title-block-banner','listing-authors','listing-license','listing-citation','listing-csl','listing-code-annotations','listing-footnotes-hover','listing-toc','listing-number-sections','listing-back-to-top-navigation','listing-comments','listing-knitr','listing-title','listing-description','listing-date','listing-categories','listing-image','listing-image-alt','listing-path','listing-outputHref','listing-date-modified','listing-author','listing-filename','listing-file-modified','listing-reading-time','listing-word-count','listing-toc-depth','listing-engine','listing-code-links','listing-resources','listing-subtitle','listing-include-in-header','listing-jupyter','listing-aliases','listing-quarto-wizard','listing-alt-text','listing-editor',{ data: ['index'] },{ data: ['categories'] },{ data: ['listing-date-sort'] },{ data: ['listing-date-modified-sort'] },{ data: ['listing-file-modified-sort'] },{ data: ['listing-reading-time-sort'] },{ data: ['listing-word-count-sort'] }],
+      valueNames: ['listing-project','listing-website','listing-format','listing-lightbox','listing-execute','listing-filters','listing-extensions','listing-engines','listing-language','listing-freeze','listing-title-block-banner','listing-open-graph','listing-authors','listing-license','listing-citation','listing-csl','listing-code-annotations','listing-footnotes-hover','listing-toc','listing-number-sections','listing-back-to-top-navigation','listing-comments','listing-knitr','listing-title','listing-description','listing-date','listing-categories','listing-image','listing-image-alt','listing-path','listing-outputHref','listing-date-modified','listing-author','listing-filename','listing-file-modified','listing-reading-time','listing-word-count','listing-toc-depth','listing-engine','listing-code-links','listing-resources','listing-subtitle','listing-include-in-header','listing-jupyter','listing-aliases','listing-quarto-wizard','listing-alt-text','listing-editor',{ data: ['index'] },{ data: ['categories'] },{ data: ['listing-date-sort'] },{ data: ['listing-date-modified-sort'] },{ data: ['listing-file-modified-sort'] },{ data: ['listing-reading-time-sort'] },{ data: ['listing-word-count-sort'] }],
       page: 6,
     pagination: { item: "<li class='page-item'><a class='page page-link' href='#'></a></li>" },
-      searchColumns: ["listing-project","listing-website","listing-format","listing-lightbox","listing-execute","listing-filters","listing-extensions","listing-engines","listing-language","listing-freeze","listing-title-block-banner","listing-authors","listing-license","listing-citation","listing-csl","listing-code-annotations","listing-footnotes-hover","listing-toc","listing-number-sections","listing-back-to-top-navigation","listing-comments","listing-knitr","listing-title","listing-description","listing-date","listing-categories","listing-image","listing-image-alt","listing-path","listing-outputHref","listing-date-modified","listing-author","listing-filename","listing-file-modified","listing-reading-time","listing-word-count","listing-toc-depth","listing-engine","listing-code-links","listing-resources","listing-subtitle","listing-include-in-header","listing-jupyter","listing-aliases","listing-quarto-wizard","listing-alt-text","listing-editor"],
+      searchColumns: ["listing-project","listing-website","listing-format","listing-lightbox","listing-execute","listing-filters","listing-extensions","listing-engines","listing-language","listing-freeze","listing-title-block-banner","listing-open-graph","listing-authors","listing-license","listing-citation","listing-csl","listing-code-annotations","listing-footnotes-hover","listing-toc","listing-number-sections","listing-back-to-top-navigation","listing-comments","listing-knitr","listing-title","listing-description","listing-date","listing-categories","listing-image","listing-image-alt","listing-path","listing-outputHref","listing-date-modified","listing-author","listing-filename","listing-file-modified","listing-reading-time","listing-word-count","listing-toc-depth","listing-engine","listing-code-links","listing-resources","listing-subtitle","listing-include-in-header","listing-jupyter","listing-aliases","listing-quarto-wizard","listing-alt-text","listing-editor"],
     };
 
     window['quarto-listings'] = window['quarto-listings'] || {};
@@ -452,7 +452,7 @@ window.Quarto = {
 <div class="quarto-listing quarto-listing-container-custom" id="listing-listing">
 <div class="list blog-list">
 
-  <article class="blog-hero" data-index="0" data-categories="dHlwc3QlMkNxdWFydG8lMkNjb21wdXRhdGlvbiUyQ2dyYW1tYXItb2YtZ3JhcGhpY3M=" data-listing-date-sort="1779235200000" data-listing-file-modified-sort="1779362637772" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="18" data-listing-word-count-sort="3534">
+  <article class="blog-hero" data-index="0" data-categories="dHlwc3QlMkNxdWFydG8lMkNjb21wdXRhdGlvbiUyQ2dyYW1tYXItb2YtZ3JhcGhpY3M=" data-listing-date-sort="1779235200000" data-listing-file-modified-sort="1779380211144" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="18" data-listing-word-count-sort="3534">
     <a class="blog-hero-thumb" href="./posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/featured.png" alt="" loading="lazy"></a>
     <div class="blog-hero-meta">
       <div class="blog-hero-eyebrow">
@@ -473,7 +473,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="1" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDZXh0ZW5zaW9ucyUyQ3ByZXNlbnRhdGlvbnM=" data-listing-date-sort="1776729600000" data-listing-file-modified-sort="1779362637767" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="534">
+  <article class="blog-row blog-row--compact" data-index="1" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDZXh0ZW5zaW9ucyUyQ3ByZXNlbnRhdGlvbnM=" data-listing-date-sort="1776729600000" data-listing-file-modified-sort="1779380211138" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="534">
     <a class="blog-thumb" href="./posts/2026-04-21-quarto-revealjs-extensions/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-04-21-quarto-revealjs-extensions/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Tuesday, the 21st of April, 2026">Tuesday, the 21st of April, 2026</time>
@@ -491,7 +491,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="2" data-categories="cXVhcnRvJTJDYnJhbmQlMkNyJTJDcHl0aG9uJTJDZ2dwbG90MiUyQ3Bsb3RuaW5l" data-listing-date-sort="1776211200000" data-listing-file-modified-sort="1779362637746" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5019">
+  <article class="blog-row blog-row--compact" data-index="2" data-categories="cXVhcnRvJTJDYnJhbmQlMkNyJTJDcHl0aG9uJTJDZ2dwbG90MiUyQ3Bsb3RuaW5l" data-listing-date-sort="1776211200000" data-listing-file-modified-sort="1779380211118" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5019">
     <a class="blog-thumb" href="./posts/2026-04-15-quarto-brand-figures-tables/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-04-15-quarto-brand-figures-tables/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Wednesday, the 15th of April, 2026">Wednesday, the 15th of April, 2026</time>
@@ -509,7 +509,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="3" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772668800000" data-listing-file-modified-sort="1779362637730" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5165">
+  <article class="blog-row blog-row--compact" data-index="3" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772668800000" data-listing-file-modified-sort="1779380211102" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="26" data-listing-word-count-sort="5165">
     <a class="blog-thumb" href="./posts/2026-03-05-typst-template-tutorial-part2/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-03-05-typst-template-tutorial-part2/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 5th of March, 2026">Thursday, the 5th of March, 2026</time>
@@ -527,7 +527,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="4" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772150400000" data-listing-file-modified-sort="1779362637724" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="23" data-listing-word-count-sort="4441">
+  <article class="blog-row blog-row--compact" data-index="4" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDbHVhJTJDcGRm" data-listing-date-sort="1772150400000" data-listing-file-modified-sort="1779380211096" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="23" data-listing-word-count-sort="4441">
     <a class="blog-thumb" href="./posts/2026-02-27-typst-template-tutorial-part1/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-02-27-typst-template-tutorial-part1/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Friday, the 27th of February, 2026">Friday, the 27th of February, 2026</time>
@@ -545,7 +545,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="5" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDcGRm" data-listing-date-sort="1768780800000" data-listing-file-modified-sort="1779362637719" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1630">
+  <article class="blog-row blog-row--compact" data-index="5" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3R5cHN0JTJDcGRm" data-listing-date-sort="1768780800000" data-listing-file-modified-sort="1779380211090" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1630">
     <a class="blog-thumb" href="./posts/2026-01-19-typst-document-dispatcher/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-01-19-typst-document-dispatcher/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 19th of January, 2026">Monday, the 19th of January, 2026</time>
@@ -563,7 +563,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="6" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1768176000000" data-listing-file-modified-sort="1779362637715" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="633">
+  <article class="blog-row blog-row--compact" data-index="6" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1768176000000" data-listing-file-modified-sort="1779380211087" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="4" data-listing-word-count-sort="633">
     <a class="blog-thumb" href="./posts/2026-01-12-quarto-wizard-2-0-0/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2026-01-12-quarto-wizard-2-0-0/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 12th of January, 2026">Monday, the 12th of January, 2026</time>
@@ -581,7 +581,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="7" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwYWN0aW9ucyUyQ2V4dGVuc2lvbnMlMkNhdXRvbWF0aW9uJTJDZGV2b3Bz" data-listing-date-sort="1765497600000" data-listing-file-modified-sort="1779362637710" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="14" data-listing-word-count-sort="2792">
+  <article class="blog-row blog-row--compact" data-index="7" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwYWN0aW9ucyUyQ2V4dGVuc2lvbnMlMkNhdXRvbWF0aW9uJTJDZGV2b3Bz" data-listing-date-sort="1765497600000" data-listing-file-modified-sort="1779380211082" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="14" data-listing-word-count-sort="2792">
     <a class="blog-thumb" href="./posts/2025-12-12-quarto-extensions-updater/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-12-12-quarto-extensions-updater/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Friday, the 12th of December, 2025">Friday, the 12th of December, 2025</time>
@@ -599,7 +599,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="8" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNwcm9kdWN0aXZpdHk=" data-listing-date-sort="1763596800000" data-listing-file-modified-sort="1779362637683" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="7" data-listing-word-count-sort="1235">
+  <article class="blog-row blog-row--compact" data-index="8" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNwcm9kdWN0aXZpdHk=" data-listing-date-sort="1763596800000" data-listing-file-modified-sort="1779380211053" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="7" data-listing-word-count-sort="1235">
     <a class="blog-thumb" href="./posts/2025-11-20-quarto-editor-settings/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-11-20-quarto-editor-settings/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 20th of November, 2025">Thursday, the 20th of November, 2025</time>
@@ -617,7 +617,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="9" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3Byb2R1Y3Rpdml0eSUyQ2Jlc3QlMjBwcmFjdGljZXMlMkNsdWE=" data-listing-date-sort="1762387200000" data-listing-file-modified-sort="1779362637682" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1798">
+  <article class="blog-row blog-row--compact" data-index="9" data-categories="cXVhcnRvJTJDZXh0ZW5zaW9ucyUyQ3Byb2R1Y3Rpdml0eSUyQ2Jlc3QlMjBwcmFjdGljZXMlMkNsdWE=" data-listing-date-sort="1762387200000" data-listing-file-modified-sort="1779380211052" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="9" data-listing-word-count-sort="1798">
     <a class="blog-thumb" href="./posts/2025-11-06-quarto-extensions-lua/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-11-06-quarto-extensions-lua/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 6th of November, 2025">Thursday, the 6th of November, 2025</time>
@@ -635,7 +635,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="10" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1760918400000" data-listing-file-modified-sort="1779362637680" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="11" data-listing-word-count-sort="2063">
+  <article class="blog-row blog-row--compact" data-index="10" data-categories="cXVhcnRvJTJDdnNjb2RlJTJDcG9zaXRyb24lMkNleHRlbnNpb25zJTJDcHJvZHVjdGl2aXR5" data-listing-date-sort="1760918400000" data-listing-file-modified-sort="1779380211051" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="11" data-listing-word-count-sort="2063">
     <a class="blog-thumb" href="./posts/2025-10-20-quarto-wizard-1-0-0/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-10-20-quarto-wizard-1-0-0/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 20th of October, 2025">Monday, the 20th of October, 2025</time>
@@ -653,7 +653,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="11" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwY29kZXNwYWNlcyUyQ3RlYWNoaW5nJTJDZGV2JTIwY29udGFpbmVy" data-listing-date-sort="1747612800000" data-listing-file-modified-sort="1779362637632" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1904">
+  <article class="blog-row blog-row--compact" data-index="11" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwY29kZXNwYWNlcyUyQ3RlYWNoaW5nJTJDZGV2JTIwY29udGFpbmVy" data-listing-date-sort="1747612800000" data-listing-file-modified-sort="1779380211002" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1904">
     <a class="blog-thumb" href="./posts/2025-05-19-quarto-codespaces/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-05-19-quarto-codespaces/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 19th of May, 2025">Monday, the 19th of May, 2025</time>
@@ -671,7 +671,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="12" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDcGRmJTJDcHJlc2VudGF0aW9ucyUyQ2RlY2t0YXBl" data-listing-date-sort="1745193600000" data-listing-file-modified-sort="1779362637630" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="810">
+  <article class="blog-row blog-row--compact" data-index="12" data-categories="cXVhcnRvJTJDcmV2ZWFsLmpzJTJDcGRmJTJDcHJlc2VudGF0aW9ucyUyQ2RlY2t0YXBl" data-listing-date-sort="1745193600000" data-listing-file-modified-sort="1779380211001" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="5" data-listing-word-count-sort="810">
     <a class="blog-thumb" href="./posts/2025-04-21-quarto-revealjs-tabset-pdf/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2025-04-21-quarto-revealjs-tabset-pdf/featured.gif" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 21st of April, 2025">Monday, the 21st of April, 2025</time>
@@ -689,7 +689,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="13" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwcGFnZXMlMkNwdWJsaXNoaW5nJTJDZGVwbG95bWVudCUyQ2dpdGh1YiUyMGFjdGlvbnM=" data-listing-date-sort="1735516800000" data-listing-file-modified-sort="1779362637624" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="13" data-listing-word-count-sort="2516">
+  <article class="blog-row blog-row--compact" data-index="13" data-categories="cXVhcnRvJTJDZ2l0aHViJTIwcGFnZXMlMkNwdWJsaXNoaW5nJTJDZGVwbG95bWVudCUyQ2dpdGh1YiUyMGFjdGlvbnM=" data-listing-date-sort="1735516800000" data-listing-file-modified-sort="1779380210994" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="13" data-listing-word-count-sort="2516">
     <a class="blog-thumb" href="./posts/2024-12-30-quarto-github-pages/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2024-12-30-quarto-github-pages/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Monday, the 30th of December, 2024">Monday, the 30th of December, 2024</time>
@@ -707,7 +707,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="14" data-categories="cXVhcnRvJTJDcSUyNmElMkNqYXZhc2NyaXB0JTJDdGhlbWUlMkNkYXJrJTIwbW9kZSUyQ2xpZ2h0JTIwbW9kZQ==" data-listing-date-sort="1685404800000" data-listing-file-modified-sort="1779362637622" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="414">
+  <article class="blog-row blog-row--compact" data-index="14" data-categories="cXVhcnRvJTJDcSUyNmElMkNqYXZhc2NyaXB0JTJDdGhlbWUlMkNkYXJrJTIwbW9kZSUyQ2xpZ2h0JTIwbW9kZQ==" data-listing-date-sort="1685404800000" data-listing-file-modified-sort="1779380210994" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="3" data-listing-word-count-sort="414">
     <a class="blog-thumb" href="./posts/2023-05-30-quarto-light-dark/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-05-30-quarto-light-dark/featured.gif" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Tuesday, the 30th of May, 2023">Tuesday, the 30th of May, 2023</time>
@@ -725,7 +725,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="15" data-categories="cXVhcnRvJTJDcSUyNmElMkNkb2NrZXI=" data-listing-date-sort="1683417600000" data-listing-file-modified-sort="1779362637614" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1867">
+  <article class="blog-row blog-row--compact" data-index="15" data-categories="cXVhcnRvJTJDcSUyNmElMkNkb2NrZXI=" data-listing-date-sort="1683417600000" data-listing-file-modified-sort="1779380210985" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="10" data-listing-word-count-sort="1867">
     <a class="blog-thumb" href="./posts/2023-05-07-quarto-docker/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-05-07-quarto-docker/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Sunday, the 7th of May, 2023">Sunday, the 7th of May, 2023</time>
@@ -743,7 +743,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="16" data-categories="cXVhcnRvJTJDcSUyNmElMkNtYXRoamF4JTJDbGF0ZXg=" data-listing-date-sort="1678579200000" data-listing-file-modified-sort="1779362637613" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="212">
+  <article class="blog-row blog-row--compact" data-index="16" data-categories="cXVhcnRvJTJDcSUyNmElMkNtYXRoamF4JTJDbGF0ZXg=" data-listing-date-sort="1678579200000" data-listing-file-modified-sort="1779380210984" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="212">
     <a class="blog-thumb" href="./posts/2023-03-12-quarto-mathjax-packages/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-03-12-quarto-mathjax-packages/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Sunday, the 12th of March, 2023">Sunday, the 12th of March, 2023</time>
@@ -761,7 +761,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="17" data-categories="cXVhcnRvJTJDcSUyNmElMkNyJTJDa25pdHI=" data-listing-date-sort="1677974400000" data-listing-file-modified-sort="1779362637612" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="310">
+  <article class="blog-row blog-row--compact" data-index="17" data-categories="cXVhcnRvJTJDcSUyNmElMkNyJTJDa25pdHI=" data-listing-date-sort="1677974400000" data-listing-file-modified-sort="1779380210983" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="2" data-listing-word-count-sort="310">
     <a class="blog-thumb" href="./posts/2023-03-05-quarto-auto-table-crossref/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2023-03-05-quarto-auto-table-crossref/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Sunday, the 5th of March, 2023">Sunday, the 5th of March, 2023</time>
@@ -779,7 +779,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="18" data-categories="ciUyQ2Jsb2dkb3duJTJDcm1hcmtkb3duJTJDaHVnbyUyQ3dlYnNpdGU=" data-listing-date-sort="1620259200000" data-listing-file-modified-sort="1779362637610" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="16" data-listing-word-count-sort="3098">
+  <article class="blog-row blog-row--compact" data-index="18" data-categories="ciUyQ2Jsb2dkb3duJTJDcm1hcmtkb3duJTJDaHVnbyUyQ3dlYnNpdGU=" data-listing-date-sort="1620259200000" data-listing-file-modified-sort="1779380210982" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="16" data-listing-word-count-sort="3098">
     <a class="blog-thumb" href="./posts/2021-05-06-floating-toc-in-blogdown/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2021-05-06-floating-toc-in-blogdown/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Thursday, the 6th of May, 2021">Thursday, the 6th of May, 2021</time>
@@ -797,7 +797,7 @@ window.Quarto = {
     </div>
   </article>
 
-  <article class="blog-row blog-row--compact" data-index="19" data-categories="ciUyQ3Zpc3VhbGlzYXRpb24lMkNnZ3Bsb3QyJTJDZ2dhbmltYXRlJTJDZnVu" data-listing-date-sort="1588723200000" data-listing-file-modified-sort="1779362637595" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="29" data-listing-word-count-sort="5615">
+  <article class="blog-row blog-row--compact" data-index="19" data-categories="ciUyQ3Zpc3VhbGlzYXRpb24lMkNnZ3Bsb3QyJTJDZ2dhbmltYXRlJTJDZnVu" data-listing-date-sort="1588723200000" data-listing-file-modified-sort="1779380210963" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="29" data-listing-word-count-sort="5615">
     <a class="blog-thumb" href="./posts/2020-05-06-ggpacman/index.html" aria-hidden="true" tabindex="-1"><img src="./posts/2020-05-06-ggpacman/featured.png" alt="" loading="lazy"></a>
     <div class="blog-meta">
       <time class="blog-date" datetime="Wednesday, the 6th of May, 2020">Wednesday, the 6th of May, 2020</time>

--- a/_site/blog.xml
+++ b/_site/blog.xml
@@ -18199,7 +18199,7 @@ font-style: inherit;">![An image]({{&lt; placeholder 900 300&gt;}})</span></span
 background-color: null;
 font-style: inherit;">quarto</span> render assets/_demo-default.qmd</span></code></pre></div></div>
 <div style="text-align: center;">
-<p><a href="assets/_demo-default.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-1"><embed src="assets/_demo-default.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/_demo-default.html" class="lightbox" data-gallery="quarto-lightbox-gallery-1" title=""><embed src="assets/_demo-default.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 <section id="enhanced-tabset-navigation" class="level2" data-number="5">
@@ -19303,7 +19303,7 @@ background-color: null;
 font-style: inherit;">quarto</span> render assets/_demo-tabset.qmd</span></code></pre></div></div>
 <p>Now, simply use the left and right arrow keys to seamlessly transition between tabs—it’s like your presentation has its own rhythm!</p>
 <div style="text-align: center;">
-<p><a href="assets/_demo-tabset.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-2"><embed src="assets/_demo-tabset.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/_demo-tabset.html" class="lightbox" data-gallery="quarto-lightbox-gallery-2" title=""><embed src="assets/_demo-tabset.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 <section id="exporting-to-pdf" class="level2" data-number="6">
@@ -19365,11 +19365,11 @@ font-style: inherit;">"my-slides.pdf"</span></span></code></pre></div></div>
 <div class="quarto-layout-row">
 <section id="default-quarto-reveal.js" class="level4 unnumbered unlisted quarto-layout-cell" style="flex-basis: 50.0%;justify-content: center;">
 <h4 class="unnumbered unlisted anchored" data-anchor-id="default-quarto-reveal.js">Default Quarto Reveal.js</h4>
-<p><a href="assets/_demo-default.pdf" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-3"><embed src="assets/_demo-default.pdf" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/_demo-default.pdf" class="lightbox" data-gallery="quarto-lightbox-gallery-3" title=""><embed src="assets/_demo-default.pdf" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </section>
 <section id="tabset-quarto-reveal.js" class="level4 unnumbered unlisted quarto-layout-cell" style="flex-basis: 50.0%;justify-content: center;">
 <h4 class="unnumbered unlisted anchored" data-anchor-id="tabset-quarto-reveal.js">Tabset Quarto Reveal.js</h4>
-<p><a href="assets/_demo-tabset.pdf" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-4"><embed src="assets/_demo-tabset.pdf" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/_demo-tabset.pdf" class="lightbox" data-gallery="quarto-lightbox-gallery-4" title=""><embed src="assets/_demo-tabset.pdf" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </section>
 </div>
 </div>
@@ -22272,7 +22272,7 @@ font-style: inherit;">"Penguin Species"</span></span>
 background-color: null;
 font-style: inherit;">```</span></span></code></pre></div></div>
 </details>
-<div class="quarto-layout-panel" data-layout-ncol="2" style="text-align:center;">
+<div class="quarto-layout-panel" style="text-align:center;" data-layout-ncol="2">
 <div class="quarto-layout-row">
 <div class="quarto-layout-cell" style="flex-basis: 50.0%;justify-content: flex-start;">
 <div class="quarto-figure quarto-figure-center">

--- a/_site/posts/2020-05-06-ggpacman/index.html
+++ b/_site/posts/2020-05-06-ggpacman/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="A ggplot2 and gganimate Version of Pac-Man – Mickaël CANOUIL">
+<meta property="og:title" content="A ggplot2 and gganimate Version of Pac-Man - mickael.canouil.fr">
 <meta property="og:description" content="The story of ggpacman. Or how to build a useless but fun R package to make a GIF of the game Pac-Man.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2020-05-06-ggpacman/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -2700,7 +2700,7 @@ Pac-Man. <em>Mickael.canouil.fr</em>. <a href="https://mickael.canouil.fr/posts/
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2021-05-06-floating-toc-in-blogdown/index.html
+++ b/_site/posts/2021-05-06-floating-toc-in-blogdown/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Add a Floating Table of Contents in blogdown – Mickaël CANOUIL">
+<meta property="og:title" content="Add a Floating Table of Contents in blogdown - mickael.canouil.fr">
 <meta property="og:description" content="How to have a table of contents (TOC) on either the left or the right side of a post? I have an answer!">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2021-05-06-floating-toc-in-blogdown/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1747,7 +1747,7 @@ CANOUIL, M. (2021-05-06). Add a Floating Table of Contents in
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2023-03-05-quarto-auto-table-crossref/index.html
+++ b/_site/posts/2023-03-05-quarto-auto-table-crossref/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Quarto Q&amp;A: How to have labels and captions for an unknown number of tables? – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto Q&amp;A: How to have labels and captions for an unknown number of tables? - mickael.canouil.fr">
 <meta property="og:description" content="A small example of how to automatically have labels and captions for an unknown number of tables in Quarto, using knitr and R.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2023-03-05-quarto-auto-table-crossref/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1416,7 +1416,7 @@ captions for an unknown number of tables? <em>Mickael.canouil.fr</em>.
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2023-03-12-quarto-mathjax-packages/index.html
+++ b/_site/posts/2023-03-12-quarto-mathjax-packages/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Quarto Q&amp;A: How to use non-default LaTeX packages/macros in MathJax? – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto Q&amp;A: How to use non-default LaTeX packages/macros in MathJax? - mickael.canouil.fr">
 <meta property="og:description" content="A second blog post of the “Quarto Q&amp;A” series on how to activate additional MathJax packages in a Quarto document.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2023-03-12-quarto-mathjax-packages/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1378,7 +1378,7 @@ packages/macros in MathJax? <em>Mickael.canouil.fr</em>. <a href="https://mickae
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2023-05-07-quarto-docker/index.html
+++ b/_site/posts/2023-05-07-quarto-docker/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Quarto Q&amp;A: How to publish your Quarto content as a Docker container? – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto Q&amp;A: How to publish your Quarto content as a Docker container? - mickael.canouil.fr">
 <meta property="og:description" content="In this blog post of the “Quarto Q&amp;A” series you will learn how to publish your Quarto project as a Docker container.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2023-05-07-quarto-docker/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1571,7 +1571,7 @@ content as a Docker container? <em>Mickael.canouil.fr</em>. <a href="https://mic
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2023-05-30-quarto-light-dark/index.html
+++ b/_site/posts/2023-05-30-quarto-light-dark/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Quarto Q&amp;A: How to have images for both light and dark theme? – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto Q&amp;A: How to have images for both light and dark theme? - mickael.canouil.fr">
 <meta property="og:description" content="In this blog post of the “Quarto Q&amp;A” series you will learn how to generate images for light and dark theme using knitr and switch between them when changing theme.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2023-05-30-quarto-light-dark/featured.gif">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -705,7 +705,7 @@ This time, I will show how to have images both for light and dark theme, when sw
 <span id="cb8-92"><a href="#cb8-92" aria-hidden="true" tabindex="-1"></a>  )</span>
 <span id="cb8-93"><a href="#cb8-93" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 </details>
-<div class="quarto-layout-panel" data-layout-ncol="2" style="text-align:center;">
+<div class="quarto-layout-panel" style="text-align:center;" data-layout-ncol="2">
 <div class="quarto-layout-row">
 <div class="quarto-layout-cell" style="flex-basis: 50.0%;justify-content: flex-start;">
 <div class="quarto-figure quarto-figure-center">
@@ -1610,7 +1610,7 @@ light and dark theme? <em>Mickael.canouil.fr</em>. <a href="https://mickael.cano
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2024-12-30-quarto-github-pages/index.html
+++ b/_site/posts/2024-12-30-quarto-github-pages/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Quarto: Publishing to GitHub Pages – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto: Publishing to GitHub Pages - mickael.canouil.fr">
 <meta property="og:description" content="In this guide, I’ll explore various methods to publish your Quarto projects to GitHub Pages. I’ll cover both manual and automated approaches to help you choose the best fit for your workflow.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2024-12-30-quarto-github-pages/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1759,7 +1759,7 @@ CANOUIL, M. (2024-12-30). Quarto: Publishing to GitHub Pages.
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2025-04-21-quarto-revealjs-tabset-pdf/index.html
+++ b/_site/posts/2025-04-21-quarto-revealjs-tabset-pdf/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Quarto: Unleash Dynamic Tabset Navigation &amp; Polished PDF Exports – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto: Unleash Dynamic Tabset Navigation &amp; Polished PDF Exports - mickael.canouil.fr">
 <meta property="og:description" content="Discover how to supercharge your Quarto presentations with interactive tabset navigation in Reveal.js and create stunning, professional PDFs. Get ready to dazzle your audience!">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2025-04-21-quarto-revealjs-tabset-pdf/featured.gif">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -544,7 +544,7 @@ This, however, requires to enable the “PDF separate fragments” option from R
 <p>Out of the box, Quarto’s default configuration requires a manual click on every tab—a small, yet frustrating interruption in the flow of your presentation. Imagine having to constantly click through your content when you could be gliding from idea to idea!</p>
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb3" data-filename="bash"><pre class="sourceCode bash cw-auto code-with-copy"><code class="sourceCode bash"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="ex">quarto</span> render assets/_demo-default.qmd</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <div style="text-align: center;">
-<p><a href="assets/_demo-default.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-1"><embed src="assets/_demo-default.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/_demo-default.html" class="lightbox" data-gallery="quarto-lightbox-gallery-1" title=""><embed src="assets/_demo-default.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 <section id="enhanced-tabset-navigation" class="level2" data-number="5">
@@ -685,7 +685,7 @@ Integrate this new functionality by including the script in your Quarto presenta
 <div class="code-copy-outer-scaffold"><div class="sourceCode" id="cb6" data-filename="bash"><pre class="sourceCode bash cw-auto code-with-copy"><code class="sourceCode bash"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="ex">quarto</span> render assets/_demo-tabset.qmd</span></code></pre></div><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></div>
 <p>Now, simply use the left and right arrow keys to seamlessly transition between tabs—it’s like your presentation has its own rhythm!</p>
 <div style="text-align: center;">
-<p><a href="assets/_demo-tabset.html" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-2"><embed src="assets/_demo-tabset.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/_demo-tabset.html" class="lightbox" data-gallery="quarto-lightbox-gallery-2" title=""><embed src="assets/_demo-tabset.html" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </div>
 </section>
 <section id="exporting-to-pdf" class="level2" data-number="6">
@@ -717,11 +717,11 @@ Integrate this new functionality by including the script in your Quarto presenta
 <div class="quarto-layout-row">
 <section id="default-quarto-reveal.js" class="level4 unnumbered unlisted quarto-layout-cell" style="flex-basis: 50.0%;justify-content: center;">
 <h4 class="unnumbered unlisted anchored" data-anchor-id="default-quarto-reveal.js">Default Quarto Reveal.js</h4>
-<p><a href="assets/_demo-default.pdf" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-3"><embed src="assets/_demo-default.pdf" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/_demo-default.pdf" class="lightbox" data-gallery="quarto-lightbox-gallery-3" title=""><embed src="assets/_demo-default.pdf" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </section>
 <section id="tabset-quarto-reveal.js" class="level4 unnumbered unlisted quarto-layout-cell" style="flex-basis: 50.0%;justify-content: center;">
 <h4 class="unnumbered unlisted anchored" data-anchor-id="tabset-quarto-reveal.js">Tabset Quarto Reveal.js</h4>
-<p><a href="assets/_demo-tabset.pdf" class="lightbox" title="" data-gallery="quarto-lightbox-gallery-4"><embed src="assets/_demo-tabset.pdf" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
+<p><a href="assets/_demo-tabset.pdf" class="lightbox" data-gallery="quarto-lightbox-gallery-4" title=""><embed src="assets/_demo-tabset.pdf" class="hero-art slide-deck img-fluid" loading="lazy"></a></p>
 </section>
 </div>
 </div>
@@ -1605,7 +1605,7 @@ CANOUIL, M. (2025-04-21). Quarto: Unleash Dynamic Tabset Navigation
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2025-05-19-quarto-codespaces/index.html
+++ b/_site/posts/2025-05-19-quarto-codespaces/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="How to use GitHub Codespaces to simplify your Quarto workshops – Mickaël CANOUIL">
+<meta property="og:title" content="How to use GitHub Codespaces to simplify your Quarto workshops - mickael.canouil.fr">
 <meta property="og:description" content="In this post, I’ll teach you the basics of GitHub Codespaces and how to use them to make it easier to teach using Quarto.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2025-05-19-quarto-codespaces/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1557,7 +1557,7 @@ Quarto workshops. <em>Mickael.canouil.fr</em>. <a href="https://mickael.canouil.
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2025-10-20-quarto-wizard-1-0-0/index.html
+++ b/_site/posts/2025-10-20-quarto-wizard-1-0-0/index.html
@@ -161,7 +161,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
  </style>
 
 
-<meta property="og:title" content="Quarto Wizard 1.0.0: Democratising Quarto Extension Management – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto Wizard 1.0.0: Democratising Quarto Extension Management - mickael.canouil.fr">
 <meta property="og:description" content="Introducing a game-changing extension for VS Code and Positron that transforms Quarto extensions management with an intuitive GUI for extensions and templates.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2025-10-20-quarto-wizard-1-0-0/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1661,7 +1661,7 @@ Extension Management. <em>Mickael.canouil.fr</em>. <a href="https://mickael.cano
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2025-11-06-quarto-extensions-lua/index.html
+++ b/_site/posts/2025-11-06-quarto-extensions-lua/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Lua Best Practices for Quarto Extensions: Building Maintainable and Robust Extensions – Mickaël CANOUIL">
+<meta property="og:title" content="Lua Best Practices for Quarto Extensions: Building Maintainable and Robust Extensions - mickael.canouil.fr">
 <meta property="og:description" content="This guide explores essential practices drawn from Quarto’s extensions and community standards, covering project structure, error handling, documentation, and release management to help transform your extensions into reliable, community-friendly tools that stand the test of time.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2025-11-06-quarto-extensions-lua/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1720,7 +1720,7 @@ Building Maintainable and Robust Extensions.
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2025-11-20-quarto-editor-settings/index.html
+++ b/_site/posts/2025-11-20-quarto-editor-settings/index.html
@@ -147,7 +147,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Optimising VS Code and Positron for Quarto: Essential Settings for Better Editing – Mickaël CANOUIL">
+<meta property="og:title" content="Optimising VS Code and Positron for Quarto: Essential Settings for Better Editing - mickael.canouil.fr">
 <meta property="og:description" content="Discover the custom settings I use in VS Code and Positron to enhance my Quarto document editing workflow, from improved Git diffs to better visual guides for nested divs.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2025-11-20-quarto-editor-settings/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1536,7 +1536,7 @@ Essential Settings for Better Editing. <em>Mickael.canouil.fr</em>. <a href="htt
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2025-12-12-quarto-extensions-updater/index.html
+++ b/_site/posts/2025-12-12-quarto-extensions-updater/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Quarto Extensions Updater: Automating Extension Maintenance with GitHub Actions – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto Extensions Updater: Automating Extension Maintenance with GitHub Actions - mickael.canouil.fr">
 <meta property="og:description" content="Discover how to automate Quarto extension updates in your repositories using a Dependabot-style GitHub Action that keeps your extensions current with zero manual effort.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2025-12-12-quarto-extensions-updater/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1705,7 +1705,7 @@ Extension Maintenance with GitHub Actions. <em>Mickael.canouil.fr</em>.
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2026-01-12-quarto-wizard-2-0-0/index.html
+++ b/_site/posts/2026-01-12-quarto-wizard-2-0-0/index.html
@@ -124,7 +124,7 @@ ul.task-list li input[type="checkbox"] {
  </style>
 
 
-<meta property="og:title" content="Quarto Wizard 2.0.0: Native Extension Management and Batch Operations – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto Wizard 2.0.0: Native Extension Management and Batch Operations - mickael.canouil.fr">
 <meta property="og:description" content="Quarto Wizard 2.0.0 brings native extension management without CLI dependency, batch operations, multi-extension selection, and a new documentation website.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2026-01-12-quarto-wizard-2-0-0/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1505,7 +1505,7 @@ Management and Batch Operations. <em>Mickael.canouil.fr</em>. <a href="https://m
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2026-01-19-typst-document-dispatcher/index.html
+++ b/_site/posts/2026-01-19-typst-document-dispatcher/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Document-Type Dispatching in Quarto Typst Extensions – Mickaël CANOUIL">
+<meta property="og:title" content="Document-Type Dispatching in Quarto Typst Extensions - mickael.canouil.fr">
 <meta property="og:description" content="Learn how to build a central dispatcher function that routes to different Typst templates based on document type. This pattern enables clean separation between document types like reports, letters, and CVs.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2026-01-19-typst-document-dispatcher/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1771,7 +1771,7 @@ Extensions. <em>Mickael.canouil.fr</em>. <a href="https://mickael.canouil.fr/pos
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2026-02-27-typst-template-tutorial-part1/index.html
+++ b/_site/posts/2026-02-27-typst-template-tutorial-part1/index.html
@@ -152,7 +152,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
-<meta property="og:title" content="Building Quarto Typst Templates: The Lua-Typst Bridge (Part 1) – Mickaël CANOUIL">
+<meta property="og:title" content="Building Quarto Typst Templates: The Lua-Typst Bridge (Part 1) - mickael.canouil.fr">
 <meta property="og:description" content="This tutorial introduces the dual-layer architecture for building Quarto Typst templates. You will learn how Lua filters and Typst functions work together to transform markdown elements into styled PDF components.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2026-02-27-typst-template-tutorial-part1/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -2299,7 +2299,7 @@ Bridge (Part 1). <em>Mickael.canouil.fr</em>. <a href="https://mickael.canouil.f
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2026-03-05-typst-template-tutorial-part2/index.html
+++ b/_site/posts/2026-03-05-typst-template-tutorial-part2/index.html
@@ -152,7 +152,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 </style>
 
 
-<meta property="og:title" content="Building Quarto Typst Templates: Advanced Patterns (Part 2) – Mickaël CANOUIL">
+<meta property="og:title" content="Building Quarto Typst Templates: Advanced Patterns (Part 2) - mickael.canouil.fr">
 <meta property="og:description" content="This tutorial continues from Part 1, exploring advanced patterns for Quarto Typst extensions. You will learn handler factories, configuration systems, type-safe value conversion, and WCAG-aware badges.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2026-03-05-typst-template-tutorial-part2/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -2646,7 +2646,7 @@ Patterns (Part 2). <em>Mickael.canouil.fr</em>. <a href="https://mickael.canouil
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2026-04-15-quarto-brand-figures-tables/index.html
+++ b/_site/posts/2026-04-15-quarto-brand-figures-tables/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Branded Figures and Tables in R and Python with Quarto – Mickaël CANOUIL">
+<meta property="og:title" content="Branded Figures and Tables in R and Python with Quarto - mickael.canouil.fr">
 <meta property="og:description" content="Style ggplot2, plotnine, gt, and great_tables outputs using Quarto’s brand feature by reading brand configuration from the QUARTO_EXECUTE_INFO environment variable at render time.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2026-04-15-quarto-brand-figures-tables/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -2090,7 +2090,7 @@ with Quarto. <em>Mickael.canouil.fr</em>. <a href="https://mickael.canouil.fr/po
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2026-04-21-quarto-revealjs-extensions/index.html
+++ b/_site/posts/2026-04-21-quarto-revealjs-extensions/index.html
@@ -145,7 +145,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 }</script>
 
 
-<meta property="og:title" content="Quarto Reveal.js extensions to sharpen your slides – Mickaël CANOUIL">
+<meta property="og:title" content="Quarto Reveal.js extensions to sharpen your slides - mickael.canouil.fr">
 <meta property="og:description" content="A short tour of small Quarto extensions that make Reveal.js presentations tidier and more interactive. Coordinated list fragments, animated code annotations, cascading headings, and keyboard-friendly tabsets, each with a minimal embedded slidedeck.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2026-04-21-quarto-revealjs-extensions/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -1569,7 +1569,7 @@ slides. <em>Mickael.canouil.fr</em>. <a href="https://mickael.canouil.fr/posts/2
     script.dataset.repoId = "MDEwOlJlcG9zaXRvcnkzNDcwODgwMDM=";
     script.dataset.category = "Blog posts";
     script.dataset.categoryId = "DIC_kwDOFLAkg84CwnxO";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html
+++ b/_site/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html
@@ -148,7 +148,7 @@ pre > code.sourceCode > span > a:first-child::before { text-decoration: underlin
 <script type="application/javascript">define('jquery', [],function() {return window.jQuery;})</script>
 
 
-<meta property="og:title" content="Gribouille: a Grammar of Graphics for Typst – Mickaël CANOUIL">
+<meta property="og:title" content="Gribouille: a Grammar of Graphics for Typst - mickael.canouil.fr">
 <meta property="og:description" content="Gribouille is a new Typst package that brings Wilkinson’s grammar of graphics natively into Typst, in the spirit of ggplot2 and plotnine. Version 0.1.0 ships alongside an updated Typst Render Quarto extension whose new typst_define() helper streams arbitrary Python and R values, from a scalar to a Polars DataFrame, straight into Typst code blocks.">
 <meta property="og:image" content="https://mickael.canouil.fr/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/featured.png">
 <meta property="og:site_name" content="Mickaël CANOUIL">
@@ -2034,7 +2034,7 @@ CANOUIL, M. (2026-05-20). Gribouille: a Grammar of Graphics for Typst.
     script.dataset.repoId = "R_kgDOSGUuww";
     script.dataset.category = "Announcements";
     script.dataset.categoryId = "DIC_kwDOSGUuw84C7KIV";
-    script.dataset.mapping = "title";
+    script.dataset.mapping = "og:title";
     script.dataset.reactionsEnabled = "1";
     script.dataset.emitMetadata = "0";
     script.dataset.inputPosition = "top";

--- a/_site/sitemap.xml
+++ b/_site/sitemap.xml
@@ -2,102 +2,102 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mickael.canouil.fr/talks/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.843Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.214Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/projects/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.834Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.207Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/blog.html</loc>
-    <lastmod>2026-05-21T11:23:57.594Z</lastmod>
+    <lastmod>2026-05-21T16:16:50.963Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-05-30-quarto-light-dark/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.622Z</lastmod>
+    <lastmod>2026-05-21T16:16:50.994Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-01-12-quarto-wizard-2-0-0/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.715Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.087Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-11-20-quarto-editor-settings/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.683Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.053Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-04-15-quarto-brand-figures-tables/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.746Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.118Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2021-05-06-floating-toc-in-blogdown/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.610Z</lastmod>
+    <lastmod>2026-05-21T16:16:50.982Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.772Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.144Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-04-21-quarto-revealjs-extensions/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.767Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.138Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-12-12-quarto-extensions-updater/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.710Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.082Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-01-19-typst-document-dispatcher/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.719Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.090Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-03-05-quarto-auto-table-crossref/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.612Z</lastmod>
+    <lastmod>2026-05-21T16:16:50.983Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-05-19-quarto-codespaces/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.632Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.002Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-03-12-quarto-mathjax-packages/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.613Z</lastmod>
+    <lastmod>2026-05-21T16:16:50.984Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-04-21-quarto-revealjs-tabset-pdf/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.630Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.001Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-02-27-typst-template-tutorial-part1/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.724Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.096Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2026-03-05-typst-template-tutorial-part2/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.730Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.102Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-10-20-quarto-wizard-1-0-0/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.680Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.051Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2023-05-07-quarto-docker/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.614Z</lastmod>
+    <lastmod>2026-05-21T16:16:50.985Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2025-11-06-quarto-extensions-lua/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.682Z</lastmod>
+    <lastmod>2026-05-21T16:16:51.052Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2020-05-06-ggpacman/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.595Z</lastmod>
+    <lastmod>2026-05-21T16:16:50.963Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/posts/2024-12-30-quarto-github-pages/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.624Z</lastmod>
+    <lastmod>2026-05-21T16:16:50.994Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/publications/index.html</loc>
-    <lastmod>2026-05-21T11:24:57.161Z</lastmod>
+    <lastmod>2026-05-21T16:17:50.118Z</lastmod>
   </url>
   <url>
     <loc>https://mickael.canouil.fr/index.html</loc>
-    <lastmod>2026-05-21T11:23:57.594Z</lastmod>
+    <lastmod>2026-05-21T16:16:50.963Z</lastmod>
   </url>
 </urlset>

--- a/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.qmd
+++ b/posts/2026-05-20-gribouille-grammar-of-graphics-for-typst/index.qmd
@@ -38,10 +38,6 @@ extensions:
       dark: "#f5f5f4"
 comments:
   giscus:
-    mapping: "title"
-    theme:
-      dark: dark_dimmed
-      light: light
     repo: mcanouil/gribouille
     repo-id: R_kgDOSGUuww
     category: Announcements

--- a/posts/_metadata.yml
+++ b/posts/_metadata.yml
@@ -7,6 +7,9 @@ freeze: true
 # Enable banner style title blocks
 title-block-banner: true
 
+open-graph:
+  title: "{{< meta title >}} - mickael.canouil.fr"
+
 authors:
   - name:
       given: Mickaël
@@ -35,7 +38,7 @@ back-to-top-navigation: true
 
 comments:
   giscus:
-    mapping: title
+    mapping: "og:title"
     theme:
       dark: dark_dimmed
       light: light


### PR DESCRIPTION
Define an open-graph title and an og:title giscus mapping in posts/_metadata.yml so all posts share the same comment thread mapping, and remove the per-post giscus override on the Gribouille post so it inherits that shared configuration.