### PR TITLE
style(theme): scale SVG images in lightbox modal

### DIFF
--- a/_extensions/mickaelcanouilfr/scss/_rules.scss
+++ b/_extensions/mickaelcanouilfr/scss/_rules.scss
@@ -4300,3 +4300,20 @@ $talks-muted: rgba($body-color, 0.62);
 .blog-category {
   @include pill-chip;
 }
+
+// =============================================================================
+// GLIGHTBOX SVG SIZING
+// =============================================================================
+// GLightbox builds a fresh <img> in its modal from the anchor's href.
+// Use vw units (not %) because .gslide-media is a flex item with width:auto,
+// so a percentage width resolves against the image's own intrinsic size.
+// The .glightbox-container prefix lifts specificity above GLightbox's
+// .desc-* .gslide-image img rules.
+.glightbox-container .gslide-image img[src$=".svg"] {
+  width: 75vw;
+  height: auto;
+  max-width: 75vw;
+  max-height: 90vh;
+  min-width: 0;
+  object-fit: contain;
+}


### PR DESCRIPTION
GLightbox rebuilds a fresh `img` in its modal from the anchor `href`, so SVG images rendered at their intrinsic size and appeared too small. This sizes them to the viewport with `vw`/`vh` units so they fill the lightbox, capped at 75vw wide and 90vh tall.